### PR TITLE
Amend public events message for ResultInformation and Correlation ID

### DIFF
--- a/specification/communication/data-plane/CallAutomation/preview/2023-01-15-preview/communicationservicescallautomation.json
+++ b/specification/communication/data-plane/CallAutomation/preview/2023-01-15-preview/communicationservicescallautomation.json
@@ -2654,7 +2654,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "recordingId": {
@@ -2685,7 +2685,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2694,7 +2694,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         }
       }
     },
@@ -2710,7 +2710,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2719,7 +2719,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         }
       }
     },
@@ -2735,7 +2735,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2770,7 +2770,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2779,7 +2779,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         },
         "recognitionType": {
           "$ref": "#/definitions/RecognitionType"
@@ -2862,7 +2862,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2871,7 +2871,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         }
       }
     },
@@ -2887,7 +2887,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2908,16 +2908,16 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
-          "type": "string"
-        },
-        "operationContext": {
-          "description": "Used by customers when calling mid-call actions to correlate the request to the response event.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
+        },
+        "operationContext": {
+          "description": "Used by customers when calling mid-call actions to correlate the request to the response event.",
+          "type": "string"
         }
       }
     },
@@ -2940,13 +2940,13 @@
           "description": "Correlation ID for event to call correlation. Also called ChainId or skype chain ID.",
           "type": "string"
         },
+        "resultInformation": {
+          "$ref": "#/definitions/ResultInformation",
+          "description": "Contains the resulting SIP code, sub-code and message."
+        },
         "operationContext": {
           "description": "Used by customers when calling mid-call actions to correlate the request to the response event.",
           "type": "string"
-        },
-        "resultInformation": {
-          "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
         }
       }
     },
@@ -2980,7 +2980,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -2989,7 +2989,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         }
       }
     },
@@ -3005,7 +3005,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -3014,7 +3014,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         }
       }
     },
@@ -3030,7 +3030,7 @@
           "type": "string"
         },
         "correlationId": {
-          "description": "Correlation ID for event to call correlation. Also called ChainId for skype chain ID.",
+          "description": "Correlation ID for event to call correlation.",
           "type": "string"
         },
         "operationContext": {
@@ -3039,7 +3039,7 @@
         },
         "resultInformation": {
           "$ref": "#/definitions/ResultInformation",
-          "description": "Contains the resulting SIP code/sub-code and message from NGC services."
+          "description": "Contains the resulting SIP code, sub-code and message."
         }
       }
     }


### PR DESCRIPTION
Amend public events message to avoid exposing internal services names-
Contracts: V4-2023-01-15-preview, GA1-2023-03-06
Fields: ResultInformation and Correlation ID